### PR TITLE
Skeleton for deploying on kraft.cloud

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,18 @@
 FROM codercom/code-server:debian AS codeserver
 
-# RUN apt-get update; \
-#     apt-get install -y git build-essential; \
-#     rm -rf /var/lib/apt/lists/*;
+RUN sudo apt update && \
+    sudo apt install -y --no-install-recommends git build-essential;
 
-WORKDIR /code
+WORKDIR /home/coder
+RUN code-server --install-extension stateful.runme
+RUN git clone --depth=1 https://github.com/stateful/vscode-runme.git
+RUN rm -rf vscode-runme/.git
+ADD .vscode vscode-runme/examples/.vscode
 
-# RUN code-server --install-extension stateful.runme
-# RUN git clone --depth=1 https://github.com/stateful/vscode-runme.git
-# RUN rm -rf vscode-runme/.git
-# ADD .vscode vscode-runme/examples/.vscode
-# RUN cat /home/coder/.config/code-server/config.yaml
-CMD ["code-server", "--auth", "none", "--app-name", "Playground"]
+#
+# Kraftcloud image
+FROM scratch
+
+COPY --from=codeserver /usr/bin/code-server /usr/bin/code-server
+# TODO: Copy dependencies of code-server
+COPY --from=codeserver /home/coder /home/coder

--- a/Kraftfile
+++ b/Kraftfile
@@ -1,9 +1,9 @@
-spec: v0.6
+spec: v0.7
 
 name: playground
 
-runtime: node:18
+runtime: base-compat:latest
 
 rootfs: ./Dockerfile
 
-cmd: ["/usr/lib/code-server/bin/code-server", "--auth", "none", "--app-name", "Playground"]
+cmd: ["/usr/bin/code-server", "--auth", "none", "--app-name", "Playground"]

--- a/kraftcloud.deploy.sh
+++ b/kraftcloud.deploy.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+kraft cloud deploy -M 2048 -p 443:8080/tls+http .


### PR DESCRIPTION
Files are updated to build a file system suitable for `kraft.cloud` using `base-compat` for the guest base.
The `Dockerfile` builds the guest filesystem on top of `scratch`. There is a placeholder for populating further needed files to the guest file system.